### PR TITLE
Move genre ID helper into ai module

### DIFF
--- a/podcast_outreach/services/ai/utils.py
+++ b/podcast_outreach/services/ai/utils.py
@@ -1,0 +1,39 @@
+"""Utility functions for AI services."""
+
+import logging
+from typing import Optional
+
+from podcast_outreach.services.ai.openai_client import OpenAIService
+from podcast_outreach.utils.file_manipulation import read_txt_file
+
+logger = logging.getLogger(__name__)
+
+# Load the genre ID prompt text
+GENRE_ID_PROMPT = read_txt_file(
+    r"prompts/podcast_search/listennotes_genre_id_prompt.txt"
+)
+
+def generate_genre_ids(openai_service: OpenAIService, run_keyword: str, record_id: Optional[str] = None):
+    """Generate ListenNotes genre IDs using OpenAI."""
+    logger.info("Calling OpenAI to generate genre IDs...")
+
+    prompt = f"""
+    User Search Query:
+    "{run_keyword}"
+
+    Provide the list of genre IDs as per the example above.
+    Return the response in JSON format with an 'ids' key containing an array of integers.
+    Do not include backticks i.e ```json
+    Example JSON Output Format: {{"ids": "139,144,157,99,90,77,253,69,104,84"}}
+    """
+
+    genre_ids = openai_service.create_chat_completion(
+        system_prompt=GENRE_ID_PROMPT,
+        prompt=prompt,
+        workflow="generate_genre_ids",
+        parse_json=True,
+        json_key="ids",
+        podcast_id=record_id,
+    )
+    logger.info("Genre IDs generated: %s", genre_ids)
+    return genre_ids

--- a/podcast_outreach/services/media/podcast_fetcher.py
+++ b/podcast_outreach/services/media/podcast_fetcher.py
@@ -16,11 +16,11 @@ from podcast_outreach.database.queries import match_suggestions as match_queries
 from podcast_outreach.database.queries import review_tasks as review_tasks_queries
 from podcast_outreach.database.connection import get_db_pool, close_db_pool # For main function
 
-from src.openai_service import OpenAIService # Still from src, needs to be moved
+from podcast_outreach.services.ai.openai_client import OpenAIService
 from podcast_outreach.integrations.listen_notes import ListenNotesAPIClient
 from podcast_outreach.integrations.podscan import PodscanAPIClient
 from podcast_outreach.utils.exceptions import APIClientError, RateLimitError
-from src.mipr_podcast import generate_genre_ids # Still from src, needs to be moved
+from podcast_outreach.services.ai.utils import generate_genre_ids
 from src.data_processor import parse_date # Still from src, needs to be moved
  
 # --- Configuration ---

--- a/src/mipr_podcast.py
+++ b/src/mipr_podcast.py
@@ -5,6 +5,7 @@ from src.external_api_service import ListenNotesAPIClient, PodscanAPIClient # RE
 from src.data_processor import DataProcessor, parse_date
 from datetime import datetime, timedelta
 from src.file_manipulation import read_txt_file
+from podcast_outreach.services.ai.utils import generate_genre_ids
 import threading
 from typing import Optional
 import time
@@ -14,43 +15,6 @@ logging.basicConfig(level=logging.INFO,
                     format='%(asctime)s [%(levelname)s] %(message)s')
 logger = logging.getLogger(__name__)
 
-genre_id_prompt = read_txt_file(
-    r"prompts/podcast_search/listennotes_genre_id_prompt.txt")
-
-def generate_genre_ids(openai_service, run_keyword, record_id=None):
-    """
-    Helper function to generate genre IDs using OpenAI.
-    
-    Args:
-        openai_service: Instance of OpenAIService
-        run_keyword: The keyword to search for
-        record_id: Optional record ID for tracking
-        
-    Returns:
-        str: Comma-separated genre IDs
-    """
-    logger.info("Calling OpenAI to generate genre IDs...")
-    
-    prompt = f"""
-    User Search Query:
-    "{run_keyword}"
-
-    Provide the list of genre IDs as per the example above. 
-    Return the response in JSON format with an 'ids' key containing an array of integers.
-    Do not include backticks i.e ```json
-    Example JSON Output Format: {{"ids": "139,144,157,99,90,77,253,69,104,84"}}
-    """
-    
-    genre_ids = openai_service.create_chat_completion(
-        system_prompt=genre_id_prompt,
-        prompt=prompt,
-        workflow="generate_genre_ids",
-        parse_json=True,
-        json_key="ids",
-        podcast_id=record_id  # Pass the record_id as podcast_id for tracking
-    )
-    logger.info(f"Genre IDs generated: {genre_ids}")
-    return genre_ids
 
 def process_mipr_podcast_search_listennotes(record_id, stop_flag: Optional[threading.Event] = None):
     # Initialize services


### PR DESCRIPTION
## Summary
- add `utils.generate_genre_ids` helper in AI services
- update `podcast_fetcher` to use new helper and OpenAI client path
- use new helper in `mipr_podcast` and drop old implementation

## Testing
- `pytest -q`